### PR TITLE
Fix dev server start error

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@babel/preset-react": "^7.0.0",
     "babel-core": "^6.17.0",
     "babel-eslint": "^10.0.3",
-    "babel-loader": "^8.0.6",
+    "babel-loader": "^8.3.0",
     "babel-preset-react-hmre": "^1.1.1",
     "clean-webpack-plugin": "^3.0.0",
     "compression-webpack-plugin": "^3.0.0",
@@ -61,7 +61,7 @@
     "prop-types": "^15.5.10",
     "react-test-renderer": "^16.11.0",
     "style-loader": "^0.23.1",
-    "webpack": "^4.36.1",
+    "webpack": "^4.47.0",
     "webpack-cli": "^3.3.6",
     "webpack-dev-server": "^3.7.2",
     "webpack-merge": "^4.1.0"


### PR DESCRIPTION
The original code has outdated webpack which is using outdated openssl functions, so it produces the next error on development server start:
```  
node:internal/crypto/hash:68
  this[kHandle] = new _Hash(algorithm, xofLen);
                  ^

...

Error: error:0308010C:digital envelope routines::unsupported
  at FSReqCallback.readFileAfterClose [as oncomplete] (node:internal/fs/read/context:68:3) {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}
```

This happens because:

> From Node version 17 onwards node upgraded from OpenSSL1.1.1 to OpenSSL3. And OpenSSL3 doesn't support some old Hashing techniques. Which is why we face this error 'ERR_OSSL_EVP_UNSUPPORTED'.


Updating to the last available version of webpack fixes this. 